### PR TITLE
Creating masks for batchsize lengths

### DIFF
--- a/quebap/util/tfutil.py
+++ b/quebap/util/tfutil.py
@@ -21,3 +21,26 @@ def get_last(tensor):
     slice_size = shape * [1, 0, 1] + [0, 1, 0]  # [dim1, 1 , dim3]
     slice_begin = shape * [0, 1, 0] + [0, -1, 0]  # [1, dim2-1, 1]
     return tf.squeeze(tf.slice(tensor, slice_begin, slice_size), [1])
+
+
+def mask_for_lengths(lengths, batch_size=None, max_length=None, mask_right=True, value=-1000.0):
+    """
+    Creates a [batch_size, max_length] mask.
+    :param lengths: int64 1-dim tensor of batch_size lengths
+    :param batch_size: int32 0-dim tensor or python int
+    :param max_length: int32 0-dim tensor or python int
+    :param mask_right: if True, everything before "lengths" becomes zero and the rest "value", else vice versa
+    :param value: value for the mask
+    :return: [batch_size, max_length] mask of zeros and "value"s
+    """
+    if max_length is None:
+        max_length = tf.reduce_max(lengths)
+    if batch_size is None:
+        batch_size = tf.shape(lengths)[0]
+    mask = tf.reshape(tf.tile(tf.range(0, max_length), [batch_size]), tf.pack([batch_size, -1]))
+    if mask_right:
+        mask = tf.greater_equal(tf.cast(mask, tf.int64), tf.expand_dims(lengths, 1))
+    else:
+        mask = tf.less(tf.cast(mask, tf.int64), tf.expand_dims(lengths, 1))
+    mask = tf.cast(tf.cast(mask, tf.float32) * value, tf.float32)
+    return mask


### PR DESCRIPTION
utility function for creating 2-dim masks. useful for example for scoring or attention in mini-batches.
