### PR TITLE
typo_readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,11 +120,11 @@ $ python3 bin/jack-train.py with reader='dam_snli_reader' loader=snli train='dat
 or the short version:
 
 ```bash
-$ python3 bin/jack-train.py with config='./conf/nli/dam.yaml'
+$ python3 bin/jack-train.py with config='./conf/snli/dam.yaml'
 ```
 
 Note, you can easily change the model to one of the other implemented NLI readers. Just checkout our configurations in
-`conf/nli/`. You will find for instance an `ESIM` reader (`esim.yaml`) which is realized using our `ModularNLIReader`, 
+`conf/snli/`. You will find for instance an `ESIM` reader (`esim.yaml`) which is realized using our `ModularNLIReader`, 
 similar to question answering. You can quickly stick together your own model in a config like that. Available modules
 can be found [here](/docs/Encoder_Modules.md).
 


### PR DESCRIPTION
There was a typo in the docs - './conf/nli' should be changed to '/.conf/snli'.